### PR TITLE
fixed name of xacro macro for raw base

### DIFF
--- a/cob_hardware_config/raw3-2/urdf/raw3-2.urdf.xacro
+++ b/cob_hardware_config/raw3-2/urdf/raw3-2.urdf.xacro
@@ -21,7 +21,7 @@
  
 
 
-  <xacro:icob_base name="base"/>	<!--with new collision_model, but no platform_controller available yet-->
+  <xacro:raw_base name="base"/>	<!--with new collision_model, but no platform_controller available yet-->
 
 
 </robot>


### PR DESCRIPTION
The name is not icob_base anymore but raw_base.

Does the base of raw3-2 looks the same as raw3-1?
